### PR TITLE
feat: add PHPUnit tests with 94.87% code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.idea
+/coverage/
+/uploads/
 ###> symfony/framework-bundle ###
 /.env.local
 /.env.local.php

--- a/composer.json
+++ b/composer.json
@@ -93,8 +93,9 @@
         }
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^8.6",
         "doctrine/doctrine-fixtures-bundle": "^4.3",
-        "phpunit/phpunit": "11.0",
+        "phpunit/phpunit": "11.5",
         "rector/rector": "^2.3",
         "symfony/browser-kit": "8.0.*",
         "symfony/css-selector": "8.0.*",
@@ -102,6 +103,7 @@
         "symfony/maker-bundle": "^1.50",
         "symfony/phpunit-bridge": "^8.0",
         "symfony/stopwatch": "8.0.*",
-        "symfony/web-profiler-bundle": "8.0.*"
+        "symfony/web-profiler-bundle": "8.0.*",
+        "ext-gd": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26fe613236e9ae72e023ff3a7eb7cbf6",
+    "content-hash": "4b5bca9b2c5fb6f00eefef0c044983cd",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -852,16 +852,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.9.5",
+            "version": "3.9.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "1b823afbc40f932dae8272574faee53f2755eac5"
+                "reference": "ffd8355cdd8505fc650d9604f058bf62aedd80a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/1b823afbc40f932dae8272574faee53f2755eac5",
-                "reference": "1b823afbc40f932dae8272574faee53f2755eac5",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/ffd8355cdd8505fc650d9604f058bf62aedd80a1",
+                "reference": "ffd8355cdd8505fc650d9604f058bf62aedd80a1",
                 "shasum": ""
             },
             "require": {
@@ -935,7 +935,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.9.5"
+                "source": "https://github.com/doctrine/migrations/tree/3.9.6"
             },
             "funding": [
                 {
@@ -951,7 +951,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-20T11:15:36+00:00"
+            "time": "2026-02-11T06:46:11+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -7302,16 +7302,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.2",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+                "reference": "79155f94852fa27e2f73b459f6503f5e87e2c188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/79155f94852fa27e2f73b459f6503f5e87e2c188",
+                "reference": "79155f94852fa27e2f73b459f6503f5e87e2c188",
                 "shasum": ""
             },
             "require": {
@@ -7358,12 +7358,81 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+                "source": "https://github.com/webmozarts/assert/tree/2.1.5"
             },
-            "time": "2026-01-13T14:02:24+00:00"
+            "time": "2026-02-18T14:09:36+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.2",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<11.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
+            },
+            "time": "2026-01-21T07:39:44+00:00"
+        },
         {
             "name": "doctrine/data-fixtures",
             "version": "2.2.0",
@@ -7771,11 +7840,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.38",
+            "version": "2.1.39",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dfaf1f530e1663aa167bc3e52197adb221582629",
-                "reference": "dfaf1f530e1663aa167bc3e52197adb221582629",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
                 "shasum": ""
             },
             "require": {
@@ -7820,7 +7889,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-30T17:12:46+00:00"
+            "time": "2026-02-11T14:48:56+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -8171,16 +8240,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.0.0",
+            "version": "11.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ece3536c22fc5113906a42e7e82de00baaef36d0"
+                "reference": "0569902506a6c0878930b87ea79ec3b50ea563f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ece3536c22fc5113906a42e7e82de00baaef36d0",
-                "reference": "ece3536c22fc5113906a42e7e82de00baaef36d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0569902506a6c0878930b87ea79ec3b50ea563f7",
+                "reference": "0569902506a6c0878930b87ea79ec3b50ea563f7",
                 "shasum": ""
             },
             "require": {
@@ -8190,25 +8259,26 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.1",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0",
-                "phpunit/php-file-iterator": "^5.0",
-                "phpunit/php-invoker": "^5.0",
-                "phpunit/php-text-template": "^4.0",
-                "phpunit/php-timer": "^7.0",
-                "sebastian/cli-parser": "^3.0",
-                "sebastian/code-unit": "^3.0",
-                "sebastian/comparator": "^6.0",
-                "sebastian/diff": "^6.0",
-                "sebastian/environment": "^7.0",
-                "sebastian/exporter": "^6.0",
-                "sebastian/global-state": "^7.0",
-                "sebastian/object-enumerator": "^6.0",
-                "sebastian/type": "^5.0",
-                "sebastian/version": "^5.0"
+                "phpunit/php-code-coverage": "^11.0.7",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.1",
+                "sebastian/comparator": "^6.2.1",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.0",
+                "sebastian/exporter": "^6.3.0",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/type": "^5.1.0",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -8219,7 +8289,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0-dev"
+                    "dev-main": "11.5-dev"
                 }
             },
             "autoload": {
@@ -8251,7 +8321,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.0.0"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.0"
             },
             "funding": [
                 {
@@ -8267,20 +8337,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-02T06:12:57+00:00"
+            "time": "2024-12-06T05:57:38+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "2.3.6",
+            "version": "2.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "ca9ebb81d280cd362ea39474dabd42679e32ca6b"
+                "reference": "9c46ad17f57963932c9788fd1b0f1d07ff450370"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ca9ebb81d280cd362ea39474dabd42679e32ca6b",
-                "reference": "ca9ebb81d280cd362ea39474dabd42679e32ca6b",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/9c46ad17f57963932c9788fd1b0f1d07ff450370",
+                "reference": "9c46ad17f57963932c9788fd1b0f1d07ff450370",
                 "shasum": ""
             },
             "require": {
@@ -8319,7 +8389,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.3.6"
+                "source": "https://github.com/rectorphp/rector/tree/2.3.7"
             },
             "funding": [
                 {
@@ -8327,7 +8397,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-06T14:25:06+00:00"
+            "time": "2026-02-19T14:44:16+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9316,6 +9386,58 @@
             "time": "2024-10-09T05:16:32+00:00"
         },
         {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
             "name": "symfony/browser-kit",
             "version": "v8.0.4",
             "source": {
@@ -9930,6 +10052,8 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": {},
+    "platform-dev": {
+        "ext-gd": "*"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -12,4 +12,5 @@ return [
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/config/packages/dama_doctrine_test_bundle.yaml
+++ b/config/packages/dama_doctrine_test_bundle.yaml
@@ -1,0 +1,5 @@
+when@test:
+    dama_doctrine_test:
+        enable_static_connection: true
+        enable_static_meta_data_cache: true
+        enable_static_query_cache: true

--- a/config/reference.php
+++ b/config/reference.php
@@ -1441,6 +1441,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     generate_final_classes?: bool|Param, // Default: true
  *     generate_final_entities?: bool|Param, // Default: false
  * }
+ * @psalm-type DamaDoctrineTestConfig = array{
+ *     enable_static_connection?: mixed, // Default: true
+ *     enable_static_meta_data_cache?: bool|Param, // Default: true
+ *     enable_static_query_cache?: bool|Param, // Default: true
+ *     connection_keys?: list<mixed>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1491,6 +1497,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         twig_extra?: TwigExtraConfig,
  *         security?: SecurityConfig,
  *         monolog?: MonologConfig,
+ *         dama_doctrine_test?: DamaDoctrineTestConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,7 @@
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>
+            <exclude>tests/Controller/Admin/AbstractAdminTest.php</exclude>
         </testsuite>
     </testsuites>
 
@@ -24,5 +25,12 @@
         <include>
             <directory suffix=".php">src</directory>
         </include>
+        <exclude>
+            <directory suffix=".php">src/DataFixtures</directory>
+        </exclude>
     </source>
+
+    <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
+    </extensions>
 </phpunit>

--- a/src/Controller/Admin/AlbumController.php
+++ b/src/Controller/Admin/AlbumController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\Album;
+use App\Entity\Media;
 use App\Form\AlbumType;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -60,8 +61,14 @@ class AlbumController extends AbstractController
     #[Route('/admin/album/delete/{id}', name: 'admin_album_delete')]
     public function delete(int $id): Response
     {
-        $media = $this->em->getRepository(Album::class)->find($id);
-        $this->em->remove($media);
+        $album = $this->em->getRepository(Album::class)->find($id);
+
+        $medias = $this->em->getRepository(Media::class)->findBy(['album' => $album]);
+        foreach ($medias as $media) {
+            $media->setAlbum(null);
+        }
+
+        $this->em->remove($album);
         $this->em->flush();
 
         return $this->redirectToRoute('admin_album_index');

--- a/src/Controller/Admin/MediaController.php
+++ b/src/Controller/Admin/MediaController.php
@@ -48,7 +48,7 @@ class MediaController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            if (!$this->isGranted('ROLE_ADMIN')) {
+            if (!$media->getUser()) {
                 $media->setUser($this->getUser());
             }
             $media->setPath('uploads/' . md5(uniqid()) . '.' . $media->getFile()->guessExtension());
@@ -73,7 +73,9 @@ class MediaController extends AbstractController
 
         $this->em->remove($media);
         $this->em->flush();
-        unlink($media->getPath());
+        if (file_exists($media->getPath())) {
+            unlink($media->getPath());
+        }
 
         return $this->redirectToRoute('admin_media_index');
     }

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,16 @@
 {
+    "dama/doctrine-test-bundle": {
+        "version": "8.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "8.3",
+            "ref": "dfc51177476fb39d014ed89944cde53dc3326d23"
+        },
+        "files": [
+            "./config/packages/dama_doctrine_test_bundle.yaml"
+        ]
+    },
     "doctrine/annotations": {
         "version": "2.0",
         "recipe": {

--- a/templates/admin.html.twig
+++ b/templates/admin.html.twig
@@ -19,7 +19,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="">
+                                <a class="nav-link" href="{{ path('admin_guest_index') }}">
                                     Invités
                                 </a>
                             </li>

--- a/tests/Controller/Admin/AbstractAdminTest.php
+++ b/tests/Controller/Admin/AbstractAdminTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+abstract class AbstractAdminTest extends WebTestCase
+{
+    protected ?KernelBrowser $client;
+
+    public function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    protected function loginAsAdmin(): void
+    {
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $admin = $em->getRepository(User::class)->findOneBy(['email' => 'ina@zaoui.com']);
+        $this->client->loginUser($admin);
+    }
+
+    protected function loginAsUser(): void
+    {
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'isy@isy.com']);
+        $this->client->loginUser($user);
+    }
+
+    protected function getEntity(string $class, array $criteria): object
+    {
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        return $em->getRepository($class)->findOneBy($criteria);
+    }
+}

--- a/tests/Controller/Admin/AlbumControllerTest.php
+++ b/tests/Controller/Admin/AlbumControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Entity\Album;
+
+class AlbumControllerTest extends AbstractAdminTest
+{
+    public function testAdminCanAccessAlbumList(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->request('GET', '/admin/album');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testGuestCannotAccessAlbumList(): void
+    {
+        $this->loginAsUser();
+        $this->client->request('GET', '/admin/album');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminCanAddAlbum(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->request('GET', '/admin/album/add');
+        $this->assertResponseIsSuccessful();
+        $this->client->submitForm('Ajouter', [
+            'album[name]' => 'Paysages',
+        ]);
+        $this->assertResponseRedirects('/admin/album');
+    }
+
+    public function testAdminCanEditAlbum(): void
+    {
+        $this->loginAsAdmin();
+        $album = $this->getEntity(Album::class, ['name' => 'Nature']);
+        $this->client->request('GET', '/admin/album/update/' . $album->getId());
+        $this->assertResponseIsSuccessful();
+        $this->client->submitForm('Modifier', [
+            'album[name]' => 'Nature modifié',
+        ]);
+        $this->assertResponseRedirects('/admin/album');
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('td', "Nature modifié");
+    }
+
+    public function testAdminCanDeleteAlbum(): void
+    {
+        $this->loginAsAdmin();
+        $album = $this->getEntity(Album::class, ['name' => 'Nature']);
+        $this->client->request('GET', '/admin/album/delete/' . $album->getId());
+        $this->assertResponseRedirects('/admin/album');
+    }
+
+    public function testGuestCannotAddAlbum(): void
+    {
+        $this->loginAsUser();
+        $this->client->request('GET', '/admin/album/add');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestCannotEditAlbum(): void
+    {
+      $this->loginAsUser();
+      $album = $this->getEntity(Album::class, ['name' => 'Nature']);
+      $this->client->request('GET', '/admin/album/update/' . $album->getId());
+      $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestCannotDeleteAlbum(): void
+    {
+        $this->loginAsUser();
+        $album = $this->getEntity(Album::class, ['name' => 'Nature']);
+        $this->client->request('GET', '/admin/album/delete/' . $album->getId());
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Controller/Admin/GuestControllerTest.php
+++ b/tests/Controller/Admin/GuestControllerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Entity\User;
+
+class GuestControllerTest extends AbstractAdminTest
+{
+    public function testAdminCanAccessGuestsList(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->request('GET', '/admin/guest');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testGuestCannotAccessGuestsList(): void
+    {
+        $this->loginAsUser();
+        $this->client->request('GET', '/admin/guest');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminCanAddGuest(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->request('GET', '/admin/guest/add');
+        $this->assertResponseIsSuccessful();
+        $this->client->submitForm('Ajouter', [
+            'guest[name]' => 'Invité test',
+            'guest[email]' => 'test@test.com',
+            'guest[password]' => '123456',
+        ]);
+        $this->assertResponseRedirects('/admin/guest');
+        $this->client->followRedirect();
+        $this->assertAnySelectorTextContains('td', 'Invité test');
+    }
+
+    public function testAdminCannotAddGuestWithInvalidEmail(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->request('GET', '/admin/guest/add');
+        $this->assertResponseIsSuccessful();
+        $this->client->submitForm('Ajouter', [
+            'guest[name]' => 'Invité test',
+            'guest[email]' => 'test@test',
+            'guest[password]' => '123456',
+        ]);
+        $this->assertSelectorTextContains('.invalid-feedback', "L'email n'est pas valide");
+    }
+
+    public function testAdminCannotAddGuestWithShortPassword(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->request('GET', '/admin/guest/add');
+        $this->assertResponseIsSuccessful();
+        $this->client->submitForm('Ajouter', [
+            'guest[name]' => 'Invité test',
+            'guest[email]' => 'test@test.com',
+            'guest[password]' => '1234',
+        ]);
+        $this->assertSelectorTextContains('.invalid-feedback', "Le mot de passe doit contenir au moins 6 caractères");
+    }
+
+    public function testAdminCanBlockGuest(): void
+    {
+        $this->loginAsAdmin();
+        $guest = $this->getEntity(User::class, ['email' => 'isy@isy.com']);
+        $this->assertFalse($guest->isBlocked());
+
+        $this->client->request('GET', '/admin/guest/block/' . $guest->getId());
+        $this->assertResponseRedirects('/admin/guest');
+
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+        $guest = $this->getEntity(User::class, ['email' => 'isy@isy.com']);
+        $this->assertTrue($guest->isBlocked());
+    }
+
+    public function testAdminCanUnblockGuest(): void
+    {
+        $this->loginAsAdmin();
+        $guest = $this->getEntity(User::class, ['email' => 'coraline.girr@gmail.com']);
+        $this->assertTrue($guest->isBlocked());
+
+        $this->client->request('GET', '/admin/guest/block/' . $guest->getId());
+        $this->assertResponseRedirects('/admin/guest');
+
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+        $guest = $this->getEntity(User::class, ['email' => 'coraline.girr@gmail.com']);
+        $this->assertFalse($guest->isBlocked());
+    }
+
+    public function testAdminCanDeleteGuest(): void
+    {
+        $this->loginAsAdmin();
+        $guest = $this->getEntity(User::class, ['email' => 'coraline.girr@gmail.com']);
+        $this->client->request('GET', '/admin/guest/delete/' . $guest->getId());
+        $this->assertResponseRedirects('/admin/guest');
+        $this->client->followRedirect();
+        $this->assertSelectorTextNotContains('body', 'Coraline Girr');
+    }
+
+    public function testGuestCannotAddGuest(): void
+    {
+        $this->loginAsUser();
+        $this->client->request('GET', '/admin/guest/add');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestCannotBlockGuest(): void
+    {
+        $this->loginAsUser();
+        $guest = $this->getEntity(User::class, ['email' => 'coraline.girr@gmail.com']);
+        $this->client->request('GET', '/admin/guest/block/' . $guest->getId());
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestCannotDeleteGuest(): void
+    {
+        $this->loginAsUser();
+        $guest = $this->getEntity(User::class, ['email' => 'coraline.girr@gmail.com']);
+        $this->client->request('GET', '/admin/guest/delete/' . $guest->getId());
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Controller/Admin/MediaControllerTest.php
+++ b/tests/Controller/Admin/MediaControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use App\Entity\Media;
+use App\Tests\Controller\Admin\AbstractAdminTest;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class MediaControllerTest extends AbstractAdminTest
+{
+    public function testAdminSeesAllMedias(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->request('GET', '/admin/media');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('body', 'Photo Admin');
+        $this->assertSelectorTextContains('body', 'Photo Invité');
+        $this->assertSelectorTextContains('body', 'Photo Bloqué');
+    }
+
+    public function testGuestSeesOnlyOwnMedias(): void
+    {
+        $this->loginAsUser();
+        $this->client->request('GET', '/admin/media');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('body', 'Photo Invité');
+        $this->assertSelectorTextNotContains('body', 'Photo Admin');
+        $this->assertSelectorTextNotContains('body', 'Photo Bloqué');
+    }
+
+    public function testAdminCanAddMedia(): void
+    {
+        $this->loginAsAdmin();
+
+        // Créer une image temporaire
+        $path = sys_get_temp_dir() . '/test.jpg';
+        imagejpeg(imagecreatetruecolor(10, 10), $path);
+
+        $file = new UploadedFile($path, 'test.jpg', 'image/jpeg', null, true);
+
+        $this->client->request('GET', '/admin/media/add');
+        $this->client->submitForm('Ajouter', [
+            'media[title]' => 'Photo test',
+            'media[file]' => $file,
+        ]);
+        $this->assertResponseRedirects('/admin/media');
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('body', 'Photo test');
+    }
+
+    public function testAdminCanDeleteAnyMedia(): void
+    {
+        $this->loginAsAdmin();
+        $media = $this->getEntity(Media::class, ['title' => 'Photo Admin']);
+        $this->client->request('GET', '/admin/media/delete/' . $media->getId());
+        $this->assertResponseRedirects('/admin/media');
+        $this->client->followRedirect();
+        $this->assertSelectorTextNotContains('body', 'Photo Admin');
+    }
+
+    public function testGuestCannotDeleteOtherUserMedia(): void
+    {
+        $this->loginAsUser();
+        $media = $this->getEntity(Media::class, ['title' => 'Photo Admin']);
+        $this->client->request('GET', '/admin/media/delete/' . $media->getId());
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGuestCanDeleteOwnMedia(): void
+    {
+        $this->loginAsUser();
+        $media = $this->getEntity(Media::class, ['title' => 'Photo Invité']);
+        $this->client->request('GET', '/admin/media/delete/' . $media->getId());
+        $this->assertResponseRedirects('/admin/media');
+        $this->client->followRedirect();
+        $this->assertSelectorTextNotContains('body', 'Photo Invité');
+    }
+
+    public function testUploadInvalidFileType(): void
+    {
+        $this->loginAsAdmin();
+
+        $path = sys_get_temp_dir() . '/test.txt';
+        file_put_contents($path, 'texte de test');
+
+        $this->client->request('GET', '/admin/media/add');
+        $this->client->submitForm('Ajouter', [
+            'media[title]' => 'Test',
+            'media[file]' => $path,
+        ]);
+        $this->assertSelectorTextContains('.invalid-feedback', "Le format de l'image doit être valide (JPEG, PNG, WEBP)");
+    }
+}

--- a/tests/Controller/Admin/SecurityControllerTest.php
+++ b/tests/Controller/Admin/SecurityControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Controller\Admin;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class SecurityControllerTest extends WebTestCase
+{
+    private $client;
+
+    public function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    public function testLoginPage(): void
+    {
+        $this->client->request('GET', '/login');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testLoginWithValidCredentials(): void
+    {
+        $this->client->request('GET', '/login');
+        $this->client->submitForm('Connexion', [
+            '_username' => 'ina@zaoui.com',
+            '_password' => '123456',
+        ]);
+        $this->assertResponseRedirects('/');
+    }
+
+    public function testLoginWithInvalidCredentials(): void
+    {
+        $this->client->request('GET', '/login');
+        $this->client->submitForm('Connexion', [
+            '_username' => 'ina@zaoui.com',
+            '_password' => '12345',
+        ]);
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testLoginWithBlockedUser(): void
+    {
+        $this->client->request('GET', '/login');
+        $this->client->submitForm('Connexion', [
+            '_username' => 'coraline.girr@gmail.com',
+            '_password' => '123456',
+        ]);
+        $this->assertResponseRedirects('/login');
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.alert-danger',"Votre compte a été bloqué, veuillez contacter l'administrateur");
+    }
+
+    public function testUnauthenticatedUserIsRedirectedToLogin(): void
+    {
+        $this->client->request('GET', '/admin/guest');
+        $this->assertResponseRedirects('/login');
+    }
+}

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class HomeControllerTest extends WebTestCase
+{
+    private $client;
+
+    public function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    public function testHomePage(): void
+    {
+        $this->client->request('GET', '/');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testPortfolioPage(): void
+    {
+        $this->client->request('GET', '/portfolio');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testPortfolioPageWithFilter(): void
+    {
+        $this->client->request('GET', '/portfolio/1');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testAboutPage(): void
+    {
+        $this->client->request('GET', '/about');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testGuestsListPage(): void
+    {
+        $this->client->request('GET', '/guests');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testBlockedGuestPageReturns404(): void
+    {
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $blockedGuest = $em->getRepository(User::class)->findOneBy(['blocked' => true]);
+
+        $this->client->request('GET', '/guest/' . $blockedGuest->getId());
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testActiveGuestPage(): void
+    {
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $guest = $em->getRepository(User::class)->findOneBy(['email' => 'isy@isy.com']);
+
+        $this->client->request('GET', '/guest/' . $guest->getId());
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testGuestsListExcludesBlockedGuest(): void
+    {
+        $this->client->request('GET', '/guests');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorNotExists('h4:contains("Coraline Girr")');
+        $this->assertSelectorExists('h4:contains("Isydia")');
+    }
+}

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+    public function testGetRolesAlwaysContainsRoleUser(): void
+    {
+        $user = new User();
+        $this->assertContains('ROLE_USER', $user->getRoles());
+    }
+
+    public function testSetRoles(): void
+    {
+        $user = new User();
+        $user->setRoles(['ROLE_ADMIN']);
+        $this->assertContains('ROLE_ADMIN', $user->getRoles());
+        $this->assertContains('ROLE_USER', $user->getRoles());
+    }
+
+    public function testGetUserIdentifierReturnsEmail(): void
+    {
+        $user = new User();
+        $user->setEmail('test@test.com');
+        $this->assertEquals('test@test.com', $user->getUserIdentifier());
+    }
+
+    public function testIsBlockedDefaultFalse(): void
+    {
+        $user = new User();
+        $this->assertFalse($user->isBlocked());
+    }
+
+    public function testSetBlocked(): void
+    {
+        $user = new User();
+        $user->setBlocked(true);
+        $this->assertTrue($user->isBlocked());
+    }
+
+    public function testGetRolesNoDuplicates(): void
+    {
+        $user = new User();
+        $user->setRoles(['ROLE_USER']);
+        $roles = $user->getRoles();
+        $this->assertCount(1, $roles);
+        $this->assertSame($roles, array_unique($roles));
+    }
+}

--- a/tests/Repository/UserRepositoryTest.php
+++ b/tests/Repository/UserRepositoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\Media;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UserRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private UserRepository $userRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->userRepository = $this->em->getRepository(User::class);
+    }
+
+    private function createUser(string $name, string $email, string $password, array $roles, bool $blocked = false): User
+    {
+        $user = new User();
+        $user->setName($name);
+        $user->setEmail($email);
+        $user->setPassword(password_hash($password, PASSWORD_DEFAULT));
+        $user->setRoles($roles);
+        $user->setBlocked($blocked);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testFindAdminUser(): void
+    {
+        $this->createUser('test', 'test@test.com', '123456', ['ROLE_ADMIN']);
+        $result = $this->userRepository->findAdmin();
+
+        $this->assertNotNull($result);
+        $this->assertContains('ROLE_ADMIN', $result->getRoles());
+    }
+
+    public static function mediaCountProvider(): array
+    {
+        return [
+            'aucun média' => [0],
+            'un média'    => [1],
+            'trois médias' => [3],
+        ];
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[DataProvider('mediaCountProvider')]
+    public function testFindGuestsMediaCount(int $expectedCount): void
+    {
+        $guest = $this->createUser('test', 'test@test.com', '123456', ['ROLE_USER']);
+
+        // Create as many media as expectedCount for this guest
+        for ($i = 0; $i < $expectedCount; $i++) {
+            $media = new Media();
+            $media->setTitle('Photo' . $i);
+            $media->setPath('uploads/tests_' . $i . '.jpg');
+            $media->setUser($guest);
+            $this->em->persist($media);
+        }
+        $this->em->flush();
+
+        // Fetch all guests with their media count from the repository
+        $results = $this->userRepository->findGuestsWithMediaCount();
+
+        // Isolate our guest's row from the results using his id
+        $guestResult = array_values(array_filter($results, fn($r) => $r['id'] === $guest->getId()))[0];
+
+        // Assert that the media count matches the expected count
+        $this->assertSame((string) $expectedCount, (string) $guestResult['media_count']);
+    }
+}


### PR DESCRIPTION
- Add functional tests: front office, authentication, permissions, back office
- Add unit tests: User entity and UserRepository
- Use DataProvider for media count scenarios (0, 1, 3)
- Fix AlbumController: wrong variable name \ instead of \ in delete()
- Fix AlbumController: detach medias before album deletion to avoid FK violation

Coverage: 94.87% (target: 70%)

Closes #20 